### PR TITLE
Add config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-
+munki-trello.cfg
 secrets.txt
+*.pyc

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ $ python munki-trello.py --boardid 12345 --key myverylongkey --token myevenlonge
 * ``--boardid``: Required. The ID of your Trello board.
 * ``--key``: Required. Your Trello API key.
 * ``--token``: Required. Your Trello User Token.
+* ``--config``: Optional. A file to read configuation settings from. 
 * ``--to-dev-list``: Optional. The name of your 'To Development' list. Defaults to ``To Development``.
 * ``--dev-list``: Optional. The name of your 'Development' list. Defaults to ``Development``.
 * ``--to-test-list``: Optional. The name of your 'To Testing' list. Defaults to ``To Testing``.
@@ -53,6 +54,22 @@ $ python munki-trello.py --boardid 12345 --key myverylongkey --token myevenlonge
 * ``--suffix``: The suffix that will be put after the dated 'Production' lists. Defaults to ``Production``.
 * ``--repo-path``: The path to your Munki repository. Defaults to ``/Volumes/Munki``.
 * ``--makecatalogs``: The path to ``makecatalogs``. Defaults to ``/usr/local/munki/makecatalogs``.
+
+## Configuration file
+
+You can give all of the comamand line options in a configuration file,
+which will be read first. The default configuration file
+locations are:
+    /etc/munki-trello/munki-trello.cfg
+    ./munki-trello.cfg
+and these will always be checked. You can also add an extra config
+file location by using the --config command line option.
+
+N.B. Configuration files will be processed *before* command line options.
+
+Options on the command line will be used in preference to those in the
+configuration file. An example configuration file is in
+munki-trello.cfg-template.
 
 # Troubleshooting
 

--- a/munki-trello.cfg-template
+++ b/munki-trello.cfg-template
@@ -1,0 +1,74 @@
+#
+# Munki Trello Settings
+#
+# Settings for munki-trello will be read from this file; if not
+# specified here, they will take the default value.
+#
+# Any value given here can be overwritten on the command line
+#
+# The default configuration file locations are:
+#    /etc/munki-trello/munki-trello.cfg 
+#    ./munki-trello.cfg 
+# You can add an extra config file location by using the --config 
+# command line option. N.B. Configuration files will be processed 
+# *before* command line options
+#
+# This file has 4 sections:
+#   * main - main application settings
+#   * development - settings about the development board/catalog
+#   * testing - settings about the testings board/catalog
+#   * production - settings about the production board/catalog
+#
+[main]
+# The ID of the trello board - the board ID is the part after ``/b``
+# and before the name of your board in the trello URL
+# No default
+#boardid=
+# The API key and user token for trello - see README.md about generating
+# this and the token that follows
+# No default
+#key=
+#token=
+# The path to the munki `makecatalogs`` command.
+# Defaults to ``/usr/local/munki/makecatalogs``
+# makecatalogs=/usr/local/munki/makecatalogs
+# The path to the Munki repository being used
+# Defaults to ``Volumes/Munki``
+repo_path=/Volumes/Munki
+
+# Settings for the development catalog and list
+[development]
+# The name trello list for development
+# Defaults to Development
+#list=Development
+# The name of the munki catalog for development
+# Defaults to development
+#catalog=development
+# The name of the 'To Development' list in trello
+# Defaults to 'To Development'
+#to_list='To Development'
+
+# Settings for the testing catalog and list
+[testing]
+# The name trello list for testing
+# Defaults to Testing
+#list=Testing
+# The name of the munki catalog for testing
+# Defaults to testing
+#catalog=testing
+# The name of the 'To Testing' list in trello
+# Defaults to 'To Testing'
+#to_list='To Testing'
+
+# Settings for the production catalog and list
+[production]
+# The name of the munki catalog for production
+# Defaults to production
+#catalog=production
+# The name of the 'To Production' list in trello
+# Defaults to 'To Production'
+#to_list='To Production'
+# The suffix to add to the dated boards that are created
+# as packages are moved into the production catalog
+# Defaults to 'Production'
+#suffix=Production

--- a/munki-trello.py
+++ b/munki-trello.py
@@ -131,7 +131,6 @@ def migrate_packages(trello_connection, source_cards,
 
                    plistlib.writePlist(plist, pkgsinfo)
 
-                   print 'UPDATING'
                    trello_connection.cards.update_idList(card['id'], dest_list_id)
                    run_makecatalogs = run_makecatalogs + 1
                    break


### PR DESCRIPTION
Alter munki-trello to read and use a configuration file, using the
python default ConfigParser module style syntax for the configuration
file. This will read the configuration file from a set of default
locations, or one specified on the command line.

A template for the configuration file is provided, with some comments,
and the README.md has been updated with this new option.

In order to make sure that the command line options override the
configuration file, the defaults are now set in the configuration file
parsing, rather than on the command line options.
