### PR TITLE
Add automatic staging of packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a script that utilises a Trello board to manage the promotion of Munki i
 * Testing: Items here are in testing.
 * To Production: Items here will be moved into production on the next run.
 
-When items are moved into production, they are moved to a dated list, so you have a history of when items were placed into production. One list will be made per day.
+When items are moved into production, they can be moved to a dated list, so you have a history of when items were placed into production. One list will be made per day.
 
 # Usage
 
@@ -56,6 +56,10 @@ $ python munki-trello.py --boardid 12345 --key myverylongkey --token myevenlonge
 * ``--repo-path``: Optional. The path to your Munki repository. Defaults to ``/Volumes/Munki``.
 * ``--makecatalogs``: Optional. The path to ``makecatalogs``. Defaults to ``/usr/local/munki/makecatalogs``.
 * ``--date-format``: Optional. The date format to use when creating dated lists. See strftime(1) for details of the formating options.  Defaults to ``%d/%m/%y``.
+* ``--dev-stage-days``: Optional. Set the due date for autostaging; as packages are added into development, this will set the card due date to the current time plus the about of time given. You will need to seperately turn on staging, which is independent of this option.  Default: 0 (no due date set).
+* ``--stage-test``: Optional. Automatically promote packages with a due date set from the development list into the testing list. Note: there is a seperate option to enable the setting of the due date.  Default: False (no auto promotion to test).
+* ``--test-stage-dates``: Optional. Set the due date for autostaging; as packages are added into test, this will set the card due date to the current time plus the about of time given. You will need to seperately turn on staging, which is independent of this option.  Default: 0 (no due date set).
+* ``--stage-prod``: Optional. Automatically promote packages with a due date set from the testing list into the production list. Note: there is a seperate option to enable the setting of the due date.  Default: False (no auto promotion to test).
 
 ## Configuration file
 

--- a/munki-trello.cfg-template
+++ b/munki-trello.cfg-template
@@ -51,6 +51,11 @@
 # The name of the 'To Development' list in trello
 # Defaults to 'To Development'
 #to_list='To Development'
+# The amount of time in the futre that packages will be auto staged
+# to testing.
+# Note: you have to turn on auto-staging seperately (in the testing
+# section)
+#stage_days=0
 
 # Settings for the testing catalog and list
 [testing]
@@ -63,6 +68,16 @@
 # The name of the 'To Testing' list in trello
 # Defaults to 'To Testing'
 #to_list='To Testing'
+# The amount of time in the futre that packages will be auto staged
+# to production.
+# Note: you have to turn on auto-staging seperately (in the production
+# section)
+#stage_days=0
+# Do we automatically stage packges from developement to testing
+# that are past their due date 
+# Note: you have to set the stage_days time seperately (in the
+# development section)
+#autostage=0
 
 # Settings for the production catalog and list
 [production]
@@ -81,3 +96,8 @@
 # Defaults to Production
 # N.B. will only be used if 'suffix' is unset
 #list=Production
+# Do we automatically stage packges from testing to production
+# that are past their due date 
+# Note: you have to set the stage_days time seperately (in the
+# testing section)
+#autostage=0

--- a/munki-trello.py
+++ b/munki-trello.py
@@ -4,10 +4,11 @@ import plistlib
 import subprocess
 import os
 import sys
-from datetime import date
+from datetime import date, datetime, timedelta
 import requests
 import json
 import optparse
+from string import atoi
 
 from ConfigParser import RawConfigParser
 
@@ -29,6 +30,10 @@ DEFAULT_MUNKI_DEV_CATALOG = "development"
 DEFAULT_MUNKI_TEST_CATALOG = "testing"
 DEFAULT_MUNKI_PROD_CATALOG = "production"
 DEFAULT_DATE_FORMAT = '%d/%m/%y'
+DEFAULT_AUTO_STAGE_TO_TEST=False
+DEFAULT_AUTO_STAGE_TO_PROD=False
+DEFAULT_DEV_STAGE_DAYS='0'
+DEFAULT_TEST_STAGE_DAYS='0'
 
 def fail(message):
     sys.stderr.write(message)
@@ -71,6 +76,7 @@ def name_in_list(name, to_development, development, testing, to_testing, to_prod
 
 def get_app_version(card_id):
     cards = trello.cards.get_action(card_id)
+    cards.reverse() 
     for action in cards:
         if action['type']=="commentCard":
             comment_data = action['data']['text'].split("\n")
@@ -86,20 +92,28 @@ def get_app_version(card_id):
     return app_name, version
 
 def migrate_packages(trello_connection, source_cards,
-                             dest_list_id, dest_catalog_name):
+                         dest_list_id, dest_catalog_name,
+                         due=0, message=None, auto_move=False):
 
     run_makecatalogs = 0
+
+    due_date_str = None 
+    if due > 0:
+        delta = timedelta(days=due)
+        now = datetime.utcnow()
+        due_date = now + delta
+        due_date_str = due_date.strftime('%Y-%m-%dT%H:%M:%S.000Z')
 
     # Find items from the source list, update pkginfo, and change trello
     # card to dest
     for card in source_cards:
         app_name, version = get_app_version(card['id'])
 
-        plist = None
         # create a list of pkgsinfo files
         pkgsinfo_dirwalk = os.walk(os.path.join(MUNKI_PATH,'pkgsinfo'),
                                                             topdown=False)
 
+        plist = None
         for root, dirs, files in pkgsinfo_dirwalk:
            for file in files:
                # It is conceivable there are broken / non plist files
@@ -118,13 +132,22 @@ def migrate_packages(trello_connection, source_cards,
                    plistlib.writePlist(plist, pkgsinfo)
 
                    trello_connection.cards.update_idList(card['id'], dest_list_id)
+                   # If we are automatically moving cards, reset their
+                   # due date
+                   if auto_move:
+                       trello_connection.cards.update_due(card['id'], None)
+
+                   if message != None:
+                       trello_connection.cards.new_action_comment(card['id'], message)
+                   if due_date_str != None:
+                       trello_connection.cards.update_due(card['id'], due_date_str)
+         
                    run_makecatalogs = run_makecatalogs + 1
-                   break
                else:
                    plist = None
 
            if plist != None:
-              break
+                break
 
     return run_makecatalogs
 
@@ -145,17 +168,21 @@ def read_config(cmdopts):
     config.set('development', 'list', DEFAULT_DEV_LIST)
     config.set('development', 'catalog', DEFAULT_MUNKI_DEV_CATALOG)
     config.set('development', 'to_list', DEFAULT_TO_DEV_LIST)
+    config.set('development', 'stage_days', DEFAULT_DEV_STAGE_DAYS)
 
     config.add_section('testing')
     config.set('testing', 'list', DEFAULT_TEST_LIST)
     config.set('testing', 'catalog', DEFAULT_MUNKI_TEST_CATALOG)
     config.set('testing', 'to_list', DEFAULT_TO_PROD_LIST)
+    config.set('testing', 'stage_days', DEFAULT_TEST_STAGE_DAYS)
+    config.set('testing', 'autostage', DEFAULT_AUTO_STAGE_TO_TEST)
 
     config.add_section('production')
     config.set('production', 'list', DEFAULT_PROD_LIST)
     config.set('production', 'catalog', DEFAULT_MUNKI_PROD_CATALOG)
     config.set('production', 'to_list', DEFAULT_TO_PROD_LIST)
     config.set('production', 'suffix', DEFAULT_PRODUCTION_SUFFIX)
+    config.set('production', 'autostage', DEFAULT_AUTO_STAGE_TO_PROD)
 
     config_file_locations = DEFAULT_CONFIG_FILE_LOCATIONS
 
@@ -191,6 +218,12 @@ def read_config(cmdopts):
     if not cmdopts.dev_catalog:
         cmdopts.dev_catalog = config.get('development', 'catalog')
 
+    if cmdopts.dev_stage_days == None:
+        val = atoi(config.get('development', 'stage_days'))
+        cmdopts.dev_stage_days = val
+    else:
+        cmdopts.dev_stage_days == atoi(cmdopts.dev_stage_days)
+
     if not cmdopts.to_test_list:
         cmdopts.to_test_list = config.get('testing', 'to_list')
 
@@ -199,6 +232,15 @@ def read_config(cmdopts):
 
     if not cmdopts.test_catalog:
         cmdopts.test_catalog = config.get('testing', 'catalog')
+
+    if cmdopts.test_stage_days == None:
+        val = atoi(config.get('testing', 'stage_days'))
+        cmdopts.test_stage_days = val
+    else: 
+        cmdopts.test_stage_days == atoi(cmdopts.test_stage_days)
+
+    if cmdopts.stage_test == None:
+        cmdopts.test_autostage = config.get('testing', 'autostage')
 
     if not cmdopts.prod_list:
         cmdopts.prod_list = config.get('production', 'list')
@@ -214,6 +256,9 @@ def read_config(cmdopts):
     if cmdopts.prod_suffix == None:
         cmdopts.prod_suffix = config.get('production', 'suffix')
 
+    if cmdopts.stage_prod == None:
+        cmdopts.prod_autostage = config.get('production', 'autostage')
+
 def find_or_create_list(trello, board_id, name_id_dict, required_name, position):
 
     if name_id_dict.has_key(required_name):
@@ -227,6 +272,58 @@ def find_or_create_list(trello, board_id, name_id_dict, required_name, position)
 
     return new_list['id']
 
+def update_card_list(trello, app_cards, app_catalog):
+
+    for card in app_cards:
+        app_name, version = get_app_version(card['id'])
+        found = False
+        for item in app_catalog:
+            if item['name'] == app_name and item['version'] == version:
+                found = True
+        if not found:
+            trello.cards.delete(card['id'])
+
+def find_auto_migrations(card_list):
+
+    migrate_cards = []
+
+    now = datetime.utcnow()
+
+    for card in card_list:
+       if card['due'] == None:
+           continue
+       # Assumptions here:
+       # Trello will always return UTC dates in an ISO standard format
+       # Due dates are not going to be accurate to more than a second
+       # (hence the .000 in the format)
+       due = datetime.strptime(card['due'], '%Y-%m-%dT%H:%M:%S.000Z')
+       difference = now - due
+       if (now - due).total_seconds() > 0:
+           migrate_cards.append(card)
+ 
+    return migrate_cards
+
+def get_dated_board_id(trello, board_id, list_prefix, suffix, list_name,
+                                   list_names, list_positions ):
+    
+    if suffix:
+        prod_title = '%s %s' % (list_prefix, suffix)
+  
+        # Find the maximun list id from the remaining list_names:
+        positions = list_positions.values()
+        positions.sort()
+        max_position = positions[-1]
+
+        return find_or_create_list(trello, board_id,
+                                    list_names, prod_title, max_position)
+    else:
+        prod_title = list_name
+        if not list_names.has_key(prod_title):
+            fail("No '%s' list found\n" % prod_title)
+
+        return list_names[prod_title]
+
+        
 usage = "%prog [options]"
 o = optparse.OptionParser(usage=usage)
 
@@ -296,6 +393,18 @@ o.add_option("--date-format",
     help=("Date format to use when creating dated lists. See strftime(1) for details of formatting options. Defaults to '%s'. "
               % DEFAULT_DATE_FORMAT))
 
+o.add_option("--dev-stage-days",
+    help=("The number of days that a package will remain in development before being prompoted to test (if staging is enabled). Note: this does not enable staging"))
+    
+o.add_option("--test-stage-days",
+    help=("The number of days a package will remain in testing before being prompoted to production (if staging is enabled). Note: this does not enable staging"))
+
+o.add_option("--stage-test",
+    help=("Automatically promote packages past their due date from development into testing.  Note: this does not enable setting of the due date"))
+
+o.add_option("--stage-prod",
+    help=("Automatically promote packages past their due date from testing into production.  Note: this does not enable setting of the due date"))
+
 
 opts, args = o.parse_args()
 
@@ -323,6 +432,9 @@ PRODUCTION_SUFFIX = opts.prod_suffix
 MUNKI_PATH = opts.repo_path
 MAKECATALOGS = opts.makecatalogs
 DATE_FORMAT=opts.date_format
+# These need to be options:
+AUTO_STAGE_TO_TEST=opts.test_autostage
+AUTO_STAGE_TO_PROD=opts.prod_autostage
 
 if not os.path.exists(MUNKI_PATH):
     fail('Munki path not accessible')
@@ -367,38 +479,6 @@ test_id     = list_names[TEST_LIST]
 list_positions.pop(TEST_LIST)
 testing     = trello.lists.get_card(test_id)
 
-# For production we either use date + suffix or the production list.
-# However, we only need check these lists if there are things to move
-# into production:
-prod_title = None
-list_prefix = date.today().strftime(DATE_FORMAT)
-
-if len(to_production):
-
-    if PRODUCTION_SUFFIX:
-        prod_title = '%s %s' % (list_prefix, PRODUCTION_SUFFIX)
-
-        # Find the maximun list id from the remaining list_names:
-        positions = list_positions.values()
-        positions.sort()
-        if len(positions):
-            max_position = positions[-1]
-        else:
-            max_position = 1000001
-
-        prod_id = find_or_create_list(trello, BOARD_ID,
-                                    list_names, prod_title, max_position)
-    else:
-        prod_title = PROD_LIST
-        if not list_names.has_key(prod_title):
-            fail("No '%s' list found\n" % prod_title)
-
-        prod_id = list_names[prod_title]
-
-# This check may be superflous, but it helped find a bug in development
-if len(to_production) and not prod_id:
-   fail('No id found (or created) for %s\n' % prod_title)
-
 all_catalog = plistlib.readPlist(os.path.join(MUNKI_PATH, 'catalogs/all'))
 
 missing = []
@@ -423,41 +503,79 @@ for item in missing:
 
 
 run_makecatalogs = 0
+
+# Automatically migrate packages from testing to production
+# based on their due date.
+# N.B this will honour manually set due dates
+automigrations = []
+if AUTO_STAGE_TO_PROD:
+   automigrations =  find_auto_migrations(testing)
+
+if len(to_production) or len(automigrations):
+# For production we either use date + suffix or the production list.
+# However, we only need check these lists if there are things to move
+# into production:
+    prod_title = None
+    list_prefix = date.today().strftime(DATE_FORMAT)
+
+    prod_id = get_dated_board_id(trello, BOARD_ID, list_prefix,
+       PRODUCTION_SUFFIX, PROD_LIST,list_names, list_positions)
+
+    if not prod_id:
+        fail('No id found (or created) for %s\n' % prod_title)
+
+# Note that automigrations will be empty if AUTO_STAGE_TO_PROD is false
+if len(automigrations):
+    msg = 'Auto migrated from %s to production as past due date' % TEST_LIST
+    rc = migrate_packages(trello, automigrations, prod_id, PROD_CATALOG,
+                               message=msg, auto_move=True)
+    run_makecatalogs = run_makecatalogs + rc
+
 # Find the items that are in To Production and change the pkginfo
-moved_to_prod = []
 if len(to_production):
+
     rc = migrate_packages(trello, to_production, prod_id, PROD_CATALOG)
     run_makecatalogs = run_makecatalogs + rc
 
+# Automatically migrate packages from development to test
+# based on their due date.
+# N.B this will honour manually set due dates
+if AUTO_STAGE_TO_TEST:
+   automigrations =  find_auto_migrations(development)
+   if len(automigrations):
+       msg = 'Auto migrated from %s to %s as past due date' % (DEV_LIST, TEST_LIST)
+       rc = migrate_packages(trello, automigrations, test_id, TEST_CATALOG, message=msg, auto_move=True)
+       run_makecatalogs = run_makecatalogs + rc
+
 # Move cards in to_testing to testing. Update the pkginfo
 if len(to_testing):
-    rc = migrate_packages(trello, to_testing, test_id, TEST_CATALOG)
+    due_days=0
+    if opts.test_stage_days:
+        due_days=opts.test_stage_days
+
+    rc = migrate_packages(trello, to_testing, test_id, TEST_CATALOG, due=due_days)
     run_makecatalogs = run_makecatalogs + rc
 
 # Move cards in to_development to development. Update the pkginfo
 if len(to_development):
-    rc = migrate_packages(trello, to_development, dev_id, DEV_CATALOG)
+    due_days=0
+    print "DUE:", opts.dev_stage_days
+    if opts.dev_stage_days:
+        due_days=opts.dev_stage_days
+
+    rc = migrate_packages(trello, to_development, dev_id, DEV_CATALOG, due=due_days)
     run_makecatalogs = run_makecatalogs + rc
 
-# Have a look at development and find any items that aren't in the all catalog anymore
-for card in development:
-    app_name, version = get_app_version(card['id'])
-    found = False
-    for item in all_catalog:
-        if item['name'] == app_name and item['version'] == version:
-            found = True
-    if not found:
-        trello.cards.delete(card['id'])
+# Have a look at development and find any items that aren't in the all
+# catalog anymore
+# XXX(TODO): if staging check this list as it may have changed
+update_card_list(trello, development, all_catalog)
 
-# Have a look at testing and find any items that aren't in the all catalog anymore
-for card in testing:
-    app_name, version = get_app_version(card['id'])
-    found = False
-    for item in all_catalog:
-        if item['name'] == app_name and item['version'] == version:
-            found = True
-    if not found:
-        trello.cards.delete(card['id'])
+# Have a look at testing and find any items that aren't in the all
+# catalog anymore
+# XXX(TODO): if staging check this list as it may have changed
+update_card_list(trello, testing, all_catalog)
+
 # Holy crap, we're done, run makecatalogs
 if run_makecatalogs:
     task = execute([MAKECATALOGS, MUNKI_PATH])


### PR DESCRIPTION
Add the possibility to automatically stage/promote packages from development
to testing and testing to production if a due date has been set, and that due
date is in the past.

This has been implemented as 2 options:
- an autostage/promote feature
- setting a due date for packages moved into development or testing
  (independent dates can be set)

These options are independent of each other (so you can autostage with manual
due dates, or just set the due dates).

These options can also be set independently on each of the package
lists (so you can autostage into testing without having to autostage
into production).

The default behaviour (i.e. no setting of due dates, and no autostaging)
has been preserved.

(Replaces pull request #7 with a version that can be cleanly merged)
